### PR TITLE
Fix Environment Canada feed URL to use coordinate-based format

### DIFF
--- a/WeatherGetter.py
+++ b/WeatherGetter.py
@@ -22,7 +22,7 @@ class WeatherGetter:
     TODO: Refactor this into a generic WeatherGetter class.
     """
 
-    moncton = 'https://weather.gc.ca/rss/city/nb-36_e.xml'
+    moncton = 'https://weather.gc.ca/rss/weather/46.106_-64.777_e.xml'
 
     def __init__(self):
         self.http = PoolManager()


### PR DESCRIPTION
## Summary
- Update weather feed URL from `/rss/city/nb-36_e.xml` (now 404) to `/rss/weather/46.106_-64.777_e.xml`
- No parser changes needed — the new feed uses the same Atom structure and category terms

Closes #7

## Test plan
- [x] `python WeatherGetter.py` returns warnings, conditions, and forecasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)